### PR TITLE
Fix code scanning alert no. 34: Disabling certificate validation

### DIFF
--- a/packages/server-fetch/src/index.ts
+++ b/packages/server-fetch/src/index.ts
@@ -31,8 +31,9 @@ function getFetchAgent<U extends string>(
 	}
 
 	if (isHttps) {
+		const rejectUnauthorized = process.env.NODE_ENV !== 'production' && allowSelfSignedCerts ? false : true;
 		return new https.Agent({
-			rejectUnauthorized: false,
+			rejectUnauthorized,
 		});
 	}
 	return null;


### PR DESCRIPTION
Fixes [https://github.com/edperlman/discount-chat-app/security/code-scanning/34](https://github.com/edperlman/discount-chat-app/security/code-scanning/34)

To fix the problem, we need to ensure that certificate validation is not disabled in production environments. One way to achieve this is to remove the option to disable certificate validation entirely. However, if the ability to use self-signed certificates is necessary for development or testing, we can add a check to ensure that this option is only enabled in non-production environments.

The best way to fix the problem without changing existing functionality is to conditionally set `rejectUnauthorized` based on the environment. We can use an environment variable to determine if the application is running in a production environment and only allow `rejectUnauthorized: false` if it is not.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
