### PR TITLE
Fix code scanning alert no. 47: Use of password hash with insufficient computational effort

### DIFF
--- a/packages/node-poplib/package.json
+++ b/packages/node-poplib/package.json
@@ -7,5 +7,8 @@
 		"typescript": "~5.7.2"
 	},
 	"main": "./src/index.js",
-	"typings": "./dist/index.d.ts"
+	"typings": "./dist/index.d.ts",
+	"dependencies": {
+    "bcrypt": "^5.1.1"
+  }
 }

--- a/packages/node-poplib/src/index.js
+++ b/packages/node-poplib/src/index.js
@@ -28,6 +28,7 @@ var net = require('net'),
 	tls = require('tls'),
 	util = require('util'),
 	crypto = require('crypto'),
+	bcrypt = require('bcrypt'),
 	events = require('events');
 
 // Constructor
@@ -399,10 +400,7 @@ POP3Client.prototype.apop = function (username, password) {
 			'APOP',
 			username +
 				' ' +
-				crypto
-					.createHash('md5')
-					.update(self.data['apop-timestamp'] + password)
-					.digest('hex'),
+				bcrypt.hashSync(self.data['apop-timestamp'] + password, bcrypt.genSaltSync(10)),
 		);
 	}
 };


### PR DESCRIPTION
Fixes [https://github.com/edperlman/discount-chat-app/security/code-scanning/47](https://github.com/edperlman/discount-chat-app/security/code-scanning/47)

To fix the problem, we need to replace the insecure `md5` hashing with a more secure hashing algorithm. The best way to do this is to use the `bcrypt` library, which is specifically designed for secure password hashing. This will involve importing the `bcrypt` library, generating a salt, and then hashing the password with the salt.

1. Import the `bcrypt` library.
2. Replace the `md5` hashing with `bcrypt` hashing.
3. Ensure that the salt is generated and used correctly.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
