### PR TITLE
Fix code scanning alert no. 38: Regular expression injection

### DIFF
--- a/apps/meteor/package.json
+++ b/apps/meteor/package.json
@@ -444,7 +444,8 @@
 		"xml-crypto": "~3.1.0",
 		"xml-encryption": "~3.0.2",
 		"xml2js": "~0.6.2",
-		"yaqrcode": "^0.2.1"
+		"yaqrcode": "^0.2.1",
+		"lodash": "^4.17.21"
 	},
 	"meteor": {
 		"mainModule": {

--- a/apps/meteor/packages/meteor-cookies/cookies.js
+++ b/apps/meteor/packages/meteor-cookies/cookies.js
@@ -1,4 +1,5 @@
 import { Meteor } from 'meteor/meteor';
+import _ from 'lodash';
 
 let fetch;
 let WebApp;
@@ -12,11 +13,11 @@ if (Meteor.isServer) {
 const NoOp = () => {};
 const urlRE = /\/___cookie___\/set/;
 const rootUrl = Meteor.isServer
-	? process.env.ROOT_URL
-	: window.__meteor_runtime_config__.ROOT_URL || window.__meteor_runtime_config__.meteorEnv.ROOT_URL || false;
+	? _.escapeRegExp(process.env.ROOT_URL)
+	: _.escapeRegExp(window.__meteor_runtime_config__.ROOT_URL || window.__meteor_runtime_config__.meteorEnv.ROOT_URL || false);
 const mobileRootUrl = Meteor.isServer
-	? process.env.MOBILE_ROOT_URL
-	: window.__meteor_runtime_config__.MOBILE_ROOT_URL || window.__meteor_runtime_config__.meteorEnv.MOBILE_ROOT_URL || false;
+	? _.escapeRegExp(process.env.MOBILE_ROOT_URL)
+	: _.escapeRegExp(window.__meteor_runtime_config__.MOBILE_ROOT_URL || window.__meteor_runtime_config__.meteorEnv.MOBILE_ROOT_URL || false);
 
 const helpers = {
 	isUndefined(obj) {


### PR DESCRIPTION
Fixes [https://github.com/edperlman/discount-chat-app/security/code-scanning/38](https://github.com/edperlman/discount-chat-app/security/code-scanning/38)

To fix the problem, we need to sanitize the environment variables `rootUrl` and `mobileRootUrl` before using them to construct the regular expression. We can use the `_.escapeRegExp` function from the lodash library to escape any special characters in these variables. This will ensure that the regular expression behaves as expected and is not vulnerable to injection attacks.

1. Import the lodash library.
2. Use the `_.escapeRegExp` function to sanitize `rootUrl` and `mobileRootUrl` before constructing the regular expression.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
