### PR TITLE
Fix code scanning alert no. 29: Incomplete string escaping or encoding

### DIFF
--- a/ee/packages/license/src/validation/validateLicenseUrl.ts
+++ b/ee/packages/license/src/validation/validateLicenseUrl.ts
@@ -9,6 +9,7 @@ import { getResultingBehavior } from './getResultingBehavior';
 
 const validateRegex = (licenseURL: string, url: string) => {
 	licenseURL = licenseURL
+		.replace(/\\/g, '\\\\') // escape backslashes
 		.replace(/\./g, '\\.') // convert dots to literal
 		.replace(/\*/g, '.*'); // convert * to .*
 	const regex = new RegExp(`^${licenseURL}$`, 'i');


### PR DESCRIPTION
Fixes [https://github.com/edperlman/discount-chat-app/security/code-scanning/29](https://github.com/edperlman/discount-chat-app/security/code-scanning/29)

To fix the problem, we need to ensure that backslashes in the `licenseURL` string are properly escaped before constructing the regular expression. This can be done by adding an additional `replace` call to escape backslashes. The best way to fix this without changing existing functionality is to modify the `validateRegex` function to include this additional escaping step.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
