### PR TITLE
Fix code scanning alert no. 24: Incomplete multi-character sanitization

### DIFF
--- a/apps/meteor/lib/utils/stringUtils.ts
+++ b/apps/meteor/lib/utils/stringUtils.ts
@@ -1,5 +1,5 @@
 import { escapeRegExp } from '@rocket.chat/string-helpers';
-import { sanitize } from 'dompurify';
+import sanitizeHtml from 'sanitize-html';
 
 export function truncate(str: string, length: number): string {
 	return str.length > length ? `${str.slice(0, length - 3)}...` : str;
@@ -49,7 +49,7 @@ export function capitalize(_str: unknown, lowercaseRest: boolean): string {
 }
 
 export function stripTags(str: unknown): string {
-	return sanitize(makeString(str)).replace(/<\/?[^>]+>/g, '');
+	return sanitizeHtml(makeString(str));
 }
 
 export function strLeft(_str: unknown, _sep: unknown): string {


### PR DESCRIPTION
Fixes [https://github.com/edperlman/discount-chat-app/security/code-scanning/24](https://github.com/edperlman/discount-chat-app/security/code-scanning/24)

To fix the problem, we should replace the custom sanitization logic with a well-tested library that handles HTML sanitization more effectively. The `sanitize-html` library is a good choice for this purpose. We will replace the current implementation of the `stripTags` function with a call to `sanitize-html`.

1. Install the `sanitize-html` library.
2. Update the `stripTags` function to use `sanitize-html` for sanitization.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
