### PR TITLE
Fix code scanning alert no. 18: Unvalidated dynamic method call

### DIFF
--- a/apps/meteor/app/apps/server/bridges/api.ts
+++ b/apps/meteor/app/apps/server/bridges/api.ts
@@ -46,7 +46,7 @@ export class AppApisBridge extends ApiBridge {
 
 			const router = this.appRouters.get(req.params.appId);
 
-			if (router) {
+			if (router && typeof router === 'function') {
 				return router(req, res, notFound);
 			}
 


### PR DESCRIPTION
Fixes [https://github.com/edperlman/discount-chat-app/security/code-scanning/18](https://github.com/edperlman/discount-chat-app/security/code-scanning/18)

To fix the problem, we need to ensure that the `router` retrieved from `this.appRouters` is a function before attempting to call it. This can be done by adding a check to verify that `router` is indeed a function. If it is not, we should handle the case gracefully by returning a 404 response.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
