### PR TITLE
Fix code scanning alert no. 9: Use of a weak cryptographic key

### DIFF
--- a/apps/meteor/server/models/raw/FederationKeys.ts
+++ b/apps/meteor/server/models/raw/FederationKeys.ts
@@ -28,7 +28,7 @@ export class FederationKeysRaw extends BaseRaw<FederationKey> implements IFedera
 		privateKey: '' | NodeRSA | null;
 		publicKey: '' | NodeRSA | null;
 	}> {
-		const key = new NodeRSA({ b: 512 });
+		const key = new NodeRSA({ b: 2048 });
 
 		key.generateKeyPair();
 


### PR DESCRIPTION
Fixes [https://github.com/edperlman/discount-chat-app/security/code-scanning/9](https://github.com/edperlman/discount-chat-app/security/code-scanning/9)

To fix the problem, we need to increase the RSA key size from 512 bits to at least 2048 bits. This change will ensure that the generated keys are secure and comply with modern cryptographic standards. The change should be made in the `generateKeys` method where the `NodeRSA` instance is created.

Specifically, we need to update the key size parameter in the `new NodeRSA` constructor from 512 to 2048. This change will not affect the existing functionality of the code but will enhance the security of the generated keys.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
