### PR TITLE
Fix code scanning alert no. 46: Use of password hash with insufficient computational effort

### DIFF
--- a/ee/apps/account-service/src/lib/utils.ts
+++ b/ee/apps/account-service/src/lib/utils.ts
@@ -23,7 +23,8 @@ type Password =
 
 export const getPassword = (password: Password): string => {
 	if (typeof password === 'string') {
-		return crypto.createHash('sha256').update(password).digest('hex'); // lgtm [js/insufficient-password-hash]
+		const saltRounds = 10;
+		return bcrypt.hashSync(password, saltRounds);
 	}
 	if (typeof password.digest === 'undefined') {
 		throw new Error('invalid password');


### PR DESCRIPTION
Fixes [https://github.com/edperlman/discount-chat-app/security/code-scanning/46](https://github.com/edperlman/discount-chat-app/security/code-scanning/46)

To fix the problem, we need to replace the use of `crypto.createHash('sha256')` with a more secure password hashing algorithm like `bcrypt`. This will involve updating the `getPassword` function to use `bcrypt` for hashing passwords. Additionally, we need to ensure that the `validatePassword` function correctly compares the hashed passwords using `bcrypt`.

1. Update the `getPassword` function to use `bcrypt.hashSync` for hashing passwords.
2. Ensure that the `validatePassword` function uses `bcrypt.compare` to compare the hashed passwords.
3. Import the necessary `bcrypt` functions if not already imported.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
