### PR TITLE
Fix code scanning alert no. 43: Use of password hash with insufficient computational effort

### DIFF
--- a/apps/meteor/tests/end-to-end/api/users.ts
+++ b/apps/meteor/tests/end-to-end/api/users.ts
@@ -2916,7 +2916,7 @@ describe('[Users]', () => {
 					.post(api('users.deleteOwnAccount'))
 					.set(createdUserCredentials)
 					.send({
-						password: crypto.createHash('sha256').update(password, 'utf8').digest('hex'),
+						password: bcrypt.hashSync(password, 10),
 					})
 					.expect('Content-Type', 'application/json')
 					.expect(400)


### PR DESCRIPTION
Fixes [https://github.com/edperlman/discount-chat-app/security/code-scanning/43](https://github.com/edperlman/discount-chat-app/security/code-scanning/43)

To fix the problem, we need to replace the use of `crypto.createHash('sha256')` with `bcrypt.hashSync` for hashing the password. This will ensure that the password is hashed using a secure and computationally intensive method, making it more resistant to brute-force attacks.

- Replace the line that hashes the password using `crypto.createHash('sha256')` with `bcrypt.hashSync`.
- Ensure that the `bcrypt` library is imported and used correctly.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
