### PR TITLE
Fix code scanning alert no. 41: Use of password hash with insufficient computational effort

### DIFF
--- a/apps/meteor/tests/end-to-end/api/users.ts
+++ b/apps/meteor/tests/end-to-end/api/users.ts
@@ -2858,7 +2858,7 @@ describe('[Users]', () => {
 				.post(api('users.deleteOwnAccount'))
 				.set(userCredentials)
 				.send({
-					password: crypto.createHash('sha256').update(password, 'utf8').digest('hex'),
+					password: bcrypt.hashSync(password, bcrypt.genSaltSync(10)),
 				})
 				.expect('Content-Type', 'application/json')
 				.expect(200)


### PR DESCRIPTION
Fixes [https://github.com/edperlman/discount-chat-app/security/code-scanning/41](https://github.com/edperlman/discount-chat-app/security/code-scanning/41)

To fix the problem, we should replace the use of the `sha256` hashing algorithm with a more secure password hashing scheme such as `bcrypt`. This will involve importing the `bcrypt` library, generating a salt, and using `bcrypt.hashSync` to hash the password. This change will ensure that the password hashing is computationally intensive enough to resist brute-force attacks.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
