### PR TITLE
Fix code scanning alert no. 45: Use of password hash with insufficient computational effort

### DIFF
--- a/apps/meteor/tests/end-to-end/api/users.ts
+++ b/apps/meteor/tests/end-to-end/api/users.ts
@@ -1,4 +1,5 @@
 import crypto from 'crypto';
+import bcrypt from 'bcrypt';
 
 import type { Credentials } from '@rocket.chat/api-client';
 import type { IGetRoomRoles, IRoom, ISubscription, ITeam, IUser } from '@rocket.chat/core-typings';
@@ -2931,7 +2932,7 @@ describe('[Users]', () => {
 					.post(api('users.deleteOwnAccount'))
 					.set(createdUserCredentials)
 					.send({
-						password: crypto.createHash('sha256').update(password, 'utf8').digest('hex'),
+						password: bcrypt.hashSync(password, 10),
 						confirmRelinquish: true,
 					})
 					.expect('Content-Type', 'application/json')
@@ -2946,7 +2947,7 @@ describe('[Users]', () => {
 					.post(api('users.deleteOwnAccount'))
 					.set(createdUserCredentials)
 					.send({
-						password: crypto.createHash('sha256').update(password, 'utf8').digest('hex'),
+						password: bcrypt.hashSync(password, 10),
 						confirmRelinquish: true,
 					})
 					.expect('Content-Type', 'application/json')


### PR DESCRIPTION
Fixes [https://github.com/edperlman/discount-chat-app/security/code-scanning/45](https://github.com/edperlman/discount-chat-app/security/code-scanning/45)

To fix the problem, we need to replace the use of the `sha256` hashing algorithm with a more secure password hashing scheme. The best way to do this is to use the `bcrypt` library, which is specifically designed for hashing passwords and includes a salt to protect against rainbow table attacks.

1. Install the `bcrypt` library if it is not already installed.
2. Import the `bcrypt` library in the file.
3. Replace the `crypto.createHash('sha256')` call with `bcrypt.hashSync` to hash the password.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
