### PR TITLE
Fix code scanning alert no. 17: Unvalidated dynamic method call

### DIFF
--- a/apps/meteor/app/apps/server/bridges/api.ts
+++ b/apps/meteor/app/apps/server/bridges/api.ts
@@ -33,7 +33,7 @@ export class AppApisBridge extends ApiBridge {
 
 			const router = this.appRouters.get(req.params.appId);
 
-			if (router) {
+			if (router && typeof router === 'function') {
 				req._privateHash = req.params.hash;
 				return router(req, res, notFound);
 			}


### PR DESCRIPTION
Fixes [https://github.com/edperlman/discount-chat-app/security/code-scanning/17](https://github.com/edperlman/discount-chat-app/security/code-scanning/17)

To fix the problem, we need to ensure that the `router` retrieved from the `appRouters` map is a function before calling it. This can be done by adding a check to verify that `router` is a function. If it is not, we should return a 404 response.

- Add a check to verify that `router` is a function before calling it.
- Modify the code in the `apps/meteor/app/apps/server/bridges/api.ts` file to include this validation.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
