### PR TITLE
Fix code scanning alert no. 5: Missing rate limiting

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
     "express": "^4.21.2",
     "jsonwebtoken": "^9.0.0",
     "lodash": "^4.17.21",
-    "pg": "^8.11.1"
+    "pg": "^8.11.1",
+    "express-rate-limit": "^7.5.0"
   },
   "devDependencies": {
     "@types/body-parser": "^1.19.5",

--- a/src/routes/index.js
+++ b/src/routes/index.js
@@ -5,6 +5,7 @@ const homeController = require('../controllers/homeController');
 const { registerUser, loginUser, getUserProfile } = require('../controllers/userController');
 const { validateRegistration } = require('../middleware/validators');
 const { authenticateToken } = require('../middleware/authenticate'); // Import authentication middleware
+const rateLimit = require('express-rate-limit'); // Import rate limiting middleware
 
 // Debugging logs for imported functions
 console.log('registerUser:', typeof registerUser);
@@ -30,8 +31,14 @@ router.post('/register', validateRegistration, registerUser);
 // User login route
 router.post('/login', loginUser);
 
+// Set up rate limiter: maximum of 100 requests per 15 minutes
+const profileLimiter = rateLimit({
+  windowMs: 15 * 60 * 1000, // 15 minutes
+  max: 100, // max 100 requests per windowMs
+});
+
 // User profile route (protected)
-router.get('/profile', authenticateToken, getUserProfile);
+router.get('/profile', profileLimiter, authenticateToken, getUserProfile);
 
 // Export the router
 module.exports = router;


### PR DESCRIPTION
Fixes [https://github.com/edperlman/discount-chat-app/security/code-scanning/5](https://github.com/edperlman/discount-chat-app/security/code-scanning/5)

To fix the problem, we need to introduce rate limiting to the `/profile` route to prevent potential denial-of-service attacks. The best way to achieve this is by using the `express-rate-limit` package, which allows us to easily set up rate limiting middleware.

We will:
1. Install the `express-rate-limit` package.
2. Import the `express-rate-limit` package in the `src/routes/index.js` file.
3. Set up a rate limiter with appropriate configuration.
4. Apply the rate limiter to the `/profile` route.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
