### PR TITLE
Fix code scanning alert no. 25: Incomplete string escaping or encoding

### DIFF
--- a/apps/meteor/app/emoji-emojione/lib/getEmojiConfig.ts
+++ b/apps/meteor/app/emoji-emojione/lib/getEmojiConfig.ts
@@ -172,8 +172,8 @@ emojione.unicodeCharRegex = mem(emojione.unicodeCharRegex, { maxAge: 1000 });
 
 const convertShortName = mem(
 	(shortname) => {
-		// the fix is basically adding this .replace(/[+]/g, '\\$&')
-		if (typeof shortname === 'undefined' || shortname === '' || emojione.shortnames.indexOf(shortname.replace(/[+]/g, '\\$&')) === -1) {
+		// the fix is basically adding this .replace(/\\/g, '\\\\').replace(/[+]/g, '\\$&')
+		if (typeof shortname === 'undefined' || shortname === '' || emojione.shortnames.indexOf(shortname.replace(/\\/g, '\\\\').replace(/[+]/g, '\\$&')) === -1) {
 			// if the shortname doesnt exist just return the entire match
 			return shortname;
 		}


### PR DESCRIPTION
Fixes [https://github.com/edperlman/discount-chat-app/security/code-scanning/25](https://github.com/edperlman/discount-chat-app/security/code-scanning/25)

To fix the problem, we need to ensure that backslashes in the `shortname` are properly escaped before performing the replacement. This can be achieved by first replacing backslashes with double backslashes and then replacing the `+` character. This ensures that any backslashes in the input are correctly handled.

The best way to fix this without changing existing functionality is to chain the `replace` calls to first escape backslashes and then escape the `+` character. This change will be made in the `convertShortName` function.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
