### PR TITLE
Fix code scanning alert no. 23: Information exposure through a stack trace

### DIFF
--- a/apps/meteor/ee/server/services/ecdh-proxy/lib/server.ts
+++ b/apps/meteor/ee/server/services/ecdh-proxy/lib/server.ts
@@ -251,7 +251,8 @@ app.use('/sockjs/:id1/:id2/xhr_send', async (req, res) => {
 	try {
 		void proxy(req, res, session, xhrDataRequestProcess, xhrDataResponseProcess);
 	} catch (e) {
-		res.status(400).send(e instanceof Error ? e.message : String(e));
+		console.error("Error occurred:", e);
+		res.status(400).send("An error occurred while processing your request.");
 	}
 });
 
@@ -267,7 +268,8 @@ app.use('/sockjs/:id1/:id2/xhr', async (req, res) => {
 	try {
 		void proxy(req, res, session, undefined, xhrDataResponseProcess);
 	} catch (e) {
-		res.status(400).send(e instanceof Error ? e.message : String(e));
+		console.error("Error occurred:", e);
+		res.status(400).send("An error occurred while processing your request.");
 	}
 });
 


### PR DESCRIPTION
Fixes [https://github.com/edperlman/discount-chat-app/security/code-scanning/23](https://github.com/edperlman/discount-chat-app/security/code-scanning/23)

To fix the problem, we should ensure that the error message sent to the client is generic and does not reveal any sensitive information. We should log the detailed error message, including the stack trace, on the server for debugging purposes. This way, developers can still access the necessary information to debug the issue without exposing it to the client.

- Modify the catch block to log the error on the server.
- Send a generic error message to the client.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
