### PR TITLE
Fix code scanning alert no. 16: DOM text reinterpreted as HTML

### DIFF
--- a/packages/livechat/src/components/Composer/index.tsx
+++ b/packages/livechat/src/components/Composer/index.tsx
@@ -198,9 +198,9 @@ export class Composer extends Component<ComposerProps, ComposerState> {
 			return;
 		}
 
-		if (this.props.value !== el.innerHTML) {
+		if (this.props.value !== el.textContent) {
 			this.value = this.props.value ?? '';
-			el.innerHTML = this.value;
+			el.textContent = this.value;
 		}
 		replaceCaret(el);
 	}
@@ -214,7 +214,7 @@ export class Composer extends Component<ComposerProps, ComposerState> {
 		const caretPosition = this.getCaretPosition(this.el);
 		const oldText = this.el?.innerText ?? '';
 		const newText = `${oldText.slice(0, caretPosition)}${emoji}&nbsp;${oldText.slice(caretPosition)}`;
-		this.el.innerHTML = newText;
+		this.el.textContent = newText;
 		this.moveCursorToEndAndFocus(caretPosition + emoji.length + 1);
 		onChange?.(this.el.innerText);
 	}


### PR DESCRIPTION
Fixes [https://github.com/edperlman/discount-chat-app/security/code-scanning/16](https://github.com/edperlman/discount-chat-app/security/code-scanning/16)

To fix the problem, we need to ensure that any text extracted from the DOM and reinserted as HTML is properly escaped to prevent XSS attacks. The best way to do this is to use a method that safely sets the text content without interpreting it as HTML.

- We will replace the direct assignment to `el.innerHTML` with a method that safely sets the text content.
- Specifically, we will use `textContent` instead of `innerHTML` to avoid interpreting the text as HTML.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
