### PR TITLE
Fix code scanning alert no. 6: Clear text transmission of sensitive cookie

### DIFF
--- a/apps/meteor/app/file-upload/client/lib/fileUploadHandler.ts
+++ b/apps/meteor/app/file-upload/client/lib/fileUploadHandler.ts
@@ -8,7 +8,7 @@ Tracker.autorun(() => {
 	// Check for Meteor.loggingIn to be reactive and ensure it will process only after login finishes
 	// preventing race condition setting the rc_token as null forever
 	if (userId && Meteor.loggingIn() === false) {
-		const secure = location.protocol === 'https:' ? '; secure' : '';
+		const secure = '; secure; httpOnly';
 
 		document.cookie = `rc_uid=${escape(userId)}; path=/${secure}`;
 		document.cookie = `rc_token=${escape(Accounts._storedLoginToken() as string)}; path=/${secure}`;


### PR DESCRIPTION
Fixes [https://github.com/edperlman/discount-chat-app/security/code-scanning/6](https://github.com/edperlman/discount-chat-app/security/code-scanning/6)

To fix the problem, we need to ensure that the `secure` attribute is always set for the cookies, regardless of the client-side environment. This can be done by modifying the code to always include the `secure` attribute when setting the cookies. Additionally, we should include the `httpOnly` attribute to further protect the cookies from being accessed via JavaScript.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
